### PR TITLE
Add preview mode support

### DIFF
--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -60,6 +60,8 @@ function enablePreview(enabled) {
   // See https://bugzilla.mozilla.org/show_bug.cgi?id=1702759
   if (typeof RemoteSettings.enablePreviewMode == "function") {
     RemoteSettings.enablePreviewMode(enabled);
+    // Set pref to persist change across restarts.
+    Services.prefs.setBoolPref("services.settings.preview_enabled", enabled);
     return;
   }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,7 +6,7 @@
   "homepage_url": "https://github.com/mozilla-extensions/remote-settings-devtools",
 
   "permissions": [
-    "mozillaAddons",
+    "mozillaAddons"
   ],
 
   "applications": {


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1702759 we are changing the way we can point the client to the preview bucket.
Before, we were relying on preferences, now we have this new method to manipulate internal state.

This PR also toggles some security-state preferences that weren't taken into account in current/old clients versions.