### PR TITLE
Fix #44, Fix #175: show an error when server cannot be changed

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -25,6 +25,7 @@
       <option value="dev-preview">Dev (preview)</option>
       <option value="local">Local</option>
     </select>
+    <div id="environment-error" class="error">⚠️ Environment cannot be changed. Try running Firefox with environment variable <pre>MOZ_REMOTE_SETTINGS_DEVTOOLS=1</pre></div>
   </section>
 
   <section id="polling-status">

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -68,11 +68,18 @@ async function refreshUI(state) {
     pollingEndpoint,
     environment,
     history,
+    serverSettingIgnored,
   } = state;
 
   showLoading(false);
 
-  document.getElementById("environment").value = environment;
+  const environmentElt = document.getElementById("environment")
+  environmentElt.value = environment;
+  document.getElementById("environment-error").style.display = serverSettingIgnored ? "block" : "none";
+  if (serverSettingIgnored) {
+    environmentElt.setAttribute("disabled", "disabled");
+  }
+
   document.getElementById("polling-url").textContent = pollingEndpoint;
   document.getElementById("polling-url").setAttribute("href", pollingEndpoint);
   document.getElementById("local-timestamp").textContent = localTimestamp;

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -56,6 +56,15 @@ section {
 #settings {
   justify-self: end;
 }
+  #environment-error {
+    max-width: 300px;
+    word-break: unset;
+    display: none;
+  }
+
+    #environment-error pre {
+      margin: 0px;
+    }
 
 #action-box {
   justify-self: start;

--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -36,10 +36,26 @@ async function getState() {
     environment += "-preview";
   }
 
+  // Detect whether user tried to switch server, and whether it had effect or not.
+  let serverSettingIgnored = false;
+  if (Services.prefs.prefHasUserValue("services.settings.server")) {
+    const manuallySet = Services.prefs.getStringPref("services.settings.server");
+    if (manuallySet != serverURL) {
+      serverSettingIgnored = true;
+    }
+  }
+  // Same for preview mode.
+  if (Services.prefs.prefHasUserValue("services.settings.preview_enabled")) {
+    const manuallyEnabled = Services.prefs.getBoolPref("services.settings.preview_enabled");
+    if (manuallyEnabled && !previewMode) {
+      serverSettingIgnored = true;
+    }
+  }
+
   return {
-    pollingEndpoint: RemoteSettings.pollingEndpoint,
-    environment,
     ...inspected,
+    environment,
+    serverSettingIgnored,
   };
 }
 


### PR DESCRIPTION
Fix #44, Fix #175

Alternative approaches:

* Add a new field `allowServerOverride` in the `RemoteSettings.inspect()` response (ie. add `Utils.allowServerOverride` [here](https://searchfox.org/mozilla-central/rev/e69f323af80c357d287fb6314745e75c62eab92a/services/settings/remote-settings.sys.mjs#525)). Clean, but requires to ride trains before being able to use it in the Dev Tools
* Import `Utils.sys.jsm` in the DevTools `api.js` code. Less hacky to detect ignored pref change, but would break the current pattern where `RemoteSettings.*` is our interface to the internals of Gecko code
