### PR TITLE
Polish apparence after redesign of #209

### DIFF
--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -172,9 +172,10 @@ button.clear-data {
 }
 
 #sync-history > ul {
-  max-height: 12em;
+  max-height: 7em;
   overflow-y: scroll;
   margin: 0;
+  padding-left: 10px;
 }
 
 #sync-history li {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -29,11 +29,6 @@ body.loading {
   margin: 4px 8px;
 }
 
-fieldset {
-  display: inline-block;
-  vertical-align: top;
-}
-
 #header section {
   display: inline-block;
   position: relative;
@@ -80,7 +75,6 @@ button.action {
 }
 
 h2, h3 {
-  display: inline-block;
   margin: unset;
 }
 
@@ -110,9 +104,6 @@ section {
   word-break: break-all;
 }
 
-#settings {
-  justify-self: end;
-}
 #environment-error {
   max-width: 300px;
   word-break: unset;
@@ -121,10 +112,6 @@ section {
 
 #environment-error pre {
   margin: 0px;
-}
-
-#action-box {
-  justify-self: start;
 }
 
 #status table {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -98,6 +98,10 @@ section {
   word-break: break-all;
 }
 
+#environment {
+  text-align: center;
+}
+
 #environment-error {
   max-width: 300px;
   word-break: unset;

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -59,7 +59,7 @@ section {
   margin-bottom: 10px;
 }
 
-#header button {
+#env-actions button, #env-actions select {
   display: block;
   width: 91%;
   margin: 4px 8px;

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -44,12 +44,6 @@ body.loading {
   padding: 0 .3em;
 }
 
-#sync-history > ul { 
-  max-height: 12em;
-  overflow-y: scroll;
-  margin: 0;
-}
-
 button.sync {
   background: url('download.svg') no-repeat;
 }
@@ -128,7 +122,7 @@ section {
 }
 
 table {
-  border-collapse: collapse; 
+  border-collapse: collapse;
 }
 
 tr:not(:first-child) {
@@ -161,6 +155,12 @@ tr:not(:first-child) {
 .unsync::before {
   content: "⚠";
   color: var(--error-text-color);
+}
+
+#sync-history > ul {
+  max-height: 12em;
+  overflow-y: scroll;
+  margin: 0;
 }
 
 #sync-history li {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -23,51 +23,6 @@ body.loading {
   opacity: 0.5;
 }
 
-#header button {
-  display: block;
-  width: 91%;
-  margin: 4px 8px;
-}
-
-#header section {
-  display: inline-block;
-  position: relative;
-  vertical-align: top;
-  border-radius: 4px;
-}
-
-#header section h2 {
-  position: absolute;
-  font-size: medium;
-  top: -0.5em;
-  background-color: var(--in-content-box-background);
-  padding: 0 .3em;
-}
-
-button.sync {
-  background: url('download.svg') no-repeat;
-}
-
-button.clear-data {
-  background: url('broom.svg') no-repeat;
-}
-
-button.action {
-  content: ' ';
-  width: 28px;
-  height: 28px;
-  min-width: 28px;
-  background-size: 28px;
-  margin-right: 5px;
-  cursor: pointer;
-}
-
-@media (prefers-color-scheme: dark) {
-  button.action {
-    filter: invert(1);
-  }
-}
-
 h2, h3 {
   margin: unset;
 }
@@ -98,6 +53,27 @@ section {
   word-break: break-all;
 }
 
+#header button {
+  display: block;
+  width: 91%;
+  margin: 4px 8px;
+}
+
+#header section {
+  display: inline-block;
+  position: relative;
+  vertical-align: top;
+  border-radius: 4px;
+}
+
+#header section h2 {
+  position: absolute;
+  font-size: medium;
+  top: -0.5em;
+  background-color: var(--in-content-box-background);
+  padding: 0 .3em;
+}
+
 #environment {
   text-align: center;
 }
@@ -116,6 +92,7 @@ section {
   width: 100%;
   min-width: 860px;
   text-align: center;
+  border-collapse: collapse;
 }
 #status table th {
   white-space: nowrap;
@@ -124,12 +101,7 @@ section {
 #status table td:first-child, #status table th:first-child {
   text-align: left
 }
-
-table {
-  border-collapse: collapse;
-}
-
-tr:not(:first-child) {
+#status table tr:not(:first-child) {
   border-top: 1px solid #757575;
 }
 
@@ -159,6 +131,31 @@ tr:not(:first-child) {
 .unsync::before {
   content: "⚠";
   color: var(--error-text-color);
+}
+
+button.action {
+  content: ' ';
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  background-size: 28px;
+  margin-right: 5px;
+  cursor: pointer;
+  background-repeat: no-repeat;
+}
+
+@media (prefers-color-scheme: dark) {
+  button.action {
+    filter: invert(1);
+  }
+}
+
+button.sync {
+  background-image: url('download.svg');
+}
+
+button.clear-data {
+  background-image: url('broom.svg');
 }
 
 #sync-history > ul {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -59,6 +59,10 @@ section {
   margin-bottom: 10px;
 }
 
+#env-actions {
+  min-width: 8em;
+}
+
 #env-actions button, #env-actions select {
   display: block;
   width: 91%;
@@ -168,18 +172,24 @@ button.clear-data {
 }
 
 #sync-history {
-  min-width: 18em;
+  min-width: 19em;
 }
 
 #sync-history > ul {
-  max-height: 7em;
+  max-height: 14em;
   overflow-y: scroll;
   margin: 0;
   padding-left: 10px;
 }
+  @media(min-width: 1255px) {
+    /* When #header-status switches to 2 columns */
+    #sync-history > ul {
+      max-height: 7em;
+    }
+  }
 
 #sync-history li {
-  margin: 10px;
+  margin: 10px 0px 10px 10px;
 }
 
 #sync-history .status.success {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -53,6 +53,12 @@ section {
   word-break: break-all;
 }
 
+#header {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
 #header button {
   display: block;
   width: 91%;
@@ -60,7 +66,6 @@ section {
 }
 
 #header section {
-  display: inline-block;
   position: relative;
   vertical-align: top;
   border-radius: 4px;
@@ -72,6 +77,10 @@ section {
   top: -0.5em;
   background-color: var(--in-content-box-background);
   padding: 0 .3em;
+}
+
+#header-status {
+  flex-grow: 1;
 }
 
 #environment {
@@ -156,6 +165,10 @@ button.sync {
 
 button.clear-data {
   background-image: url('broom.svg');
+}
+
+#sync-history {
+  min-width: 18em;
 }
 
 #sync-history > ul {


### PR DESCRIPTION
Follow-up of #209 

I was playing with the UI before tagging it, and found some apparence inconsistencies, that this PR addresses

*Easier to review by commit*

#### Header bar elements do not fill space on empty profile

<img width="1242" alt="Screenshot 2024-05-30 at 10 38 24" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/c82cb70a-3f4f-44bb-80db-bdace6294bfb">

#### Header grows vertically when history grows

And has default left padding on `<ul>` which decenters its elements horizontally

<img width="1438" alt="Screenshot 2024-05-30 at 10 39 35" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/b739e7c7-e8fc-495a-98b7-63fbf766e0a4">

#### Select does not have same apparence as buttons

Not same margins, not centered...

<img width="241" alt="Screenshot 2024-05-30 at 10 40 47" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/d7c093fa-9023-4cd4-a25a-e22410ac9eb3">

#### Paddings between sections are inconsistent
<img width="73" alt="Screenshot 2024-05-30 at 10 41 37" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/1cb0bbbe-d719-405a-bc84-021d363ceab1">


### Now

On empty profile:

<img width="1238" alt="Screenshot 2024-05-30 at 10 48 16" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/f0d14756-f9a5-4a43-8213-7a0db636e68d">

With sync history:

<img width="1425" alt="Screenshot 2024-05-30 at 10 49 28" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/ab2a3fe3-9004-45db-a68c-9e74e2df07f6">

On small windows
<img width="933" alt="Screenshot 2024-05-30 at 11 13 56" src="https://github.com/mozilla-extensions/remote-settings-devtools/assets/546692/9a161444-3c6b-4a68-aec1-27a04fa937ea">
