### PR TITLE
Fix #251: Add option to disable signature verification

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -6,24 +6,32 @@
 </head>
 
 <body class=" loading">
-  <section id="header">
-    <section id="env-actions">
-      <h2>Environment</h2>
-      <select id="environment">
-        <option value="custom"></option>
-        <option value="prod">Prod</option>
-        <option value="prod-preview">Prod (preview)</option>
-        <option value="stage">Stage</option>
-        <option value="stage-preview">Stage (preview)</option>
-        <option value="dev">Dev</option>
-        <option value="dev-preview">Dev (preview)</option>
-        <option value="local">Local</option>
-      </select>
-      <button id="run-poll" title="Poll for changes of remote settings">Sync</button>
-      <button id="clear-all-data" title="Clear every local data">Clear all</button>
-      <div id="environment-error" class="error">⚠️ Environment cannot be changed. Try running Firefox with environment variable <pre>MOZ_REMOTE_SETTINGS_DEVTOOLS=1</pre></div>
-    </section>
-    <section id="header-status"">
+  <section id="header" class="bordered">
+    <div><!-- make a column -->
+      <section id="actions">
+        <button id="run-poll" title="Poll for changes of remote settings">Sync</button>
+        <button id="clear-all-data" title="Clear every local data">Clear all</button>
+        <div id="environment-error" class="error">⚠️ Environment cannot be changed. Try running Firefox with environment variable <pre>MOZ_REMOTE_SETTINGS_DEVTOOLS=1</pre></div>
+      </section>
+      <section id="options" class="bordered">
+        <h2>Options</h2>
+        <select id="environment">
+          <option value="custom"></option>
+          <option value="prod">Prod</option>
+          <option value="prod-preview">Prod (preview)</option>
+          <option value="stage">Stage</option>
+          <option value="stage-preview">Stage (preview)</option>
+          <option value="dev">Dev</option>
+          <option value="dev-preview">Dev (preview)</option>
+          <option value="local">Local</option>
+        </select>
+        <span>
+          <input type="checkbox" id="enable-signatures"/>
+          <label for="enable-signatures">Signatures enabled</label>
+        </span>
+      </section>
+    </div>
+    <section id="header-status" class="bordered">
       <h2>Status</h2>
       <div id="polling-error" class="error"></div>
       <dl>
@@ -41,12 +49,12 @@
         <dd id="last-check">N/A</dd>
       </dl>
     </section>
-    <section id="sync-history">
+    <section id="sync-history" class="bordered">
       <h2>Sync History</h2>
       <ul></ul>
     </section>
   </section>
-  <section id="status">
+  <section id="status" class="bordered">
     <table id="status-table">
       <thead>
         <tr>

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -69,6 +69,7 @@ async function refreshUI(state) {
     environment,
     history,
     serverSettingIgnored,
+    signaturesEnabled,
   } = state;
 
   showLoading(false);
@@ -110,6 +111,9 @@ async function refreshUI(state) {
     entryRow.querySelector(".status").className += ` ${entry.status}`;
     historyList.appendChild(entryRow);
   });
+
+  // Options
+  document.getElementById("enable-signatures").checked = signaturesEnabled;
 
   // Table of collections.
   const tpl = document.getElementById("collection-status-tpl");
@@ -199,6 +203,10 @@ async function main() {
     showGlobalError(null);
     showLoading(true);
     await remotesettings.switchEnvironment(event.target.value);
+  };
+
+  document.getElementById("enable-signatures").onchange = async (event) => {
+    await remotesettings.enableSignatureVerification(event.target.checked);
   };
 
   // Poll for changes button.

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -47,10 +47,13 @@ dd {
 }
 
 section {
-  border: 1px solid var(--in-content-border-color);
   background-color: var(--in-content-box-background);
   padding: 10px;
   word-break: break-all;
+}
+
+section.bordered {
+  border: 1px solid var(--in-content-border-color);
 }
 
 #header {
@@ -59,11 +62,11 @@ section {
   margin-bottom: 10px;
 }
 
-#env-actions {
+#options {
   min-width: 8em;
 }
 
-#env-actions button, #env-actions select {
+#options button, #options select, #options span {
   display: block;
   width: 91%;
   margin: 4px 8px;
@@ -85,6 +88,11 @@ section {
 
 #header-status {
   flex-grow: 1;
+}
+
+#actions {
+  padding: 0px;
+  padding-bottom: 10px;
 }
 
 #environment {
@@ -184,7 +192,7 @@ button.clear-data {
   @media(min-width: 1255px) {
     /* When #header-status switches to 2 columns */
     #sync-history > ul {
-      max-height: 7em;
+      max-height: 8em;
     }
   }
 

--- a/extension/experiments/remotesettings/schema.json
+++ b/extension/experiments/remotesettings/schema.json
@@ -31,6 +31,19 @@
         ]
       },
       {
+        "name": "enableSignatureVerification",
+        "type": "function",
+        "description": "Enable signatures verification",
+        "async": true,
+        "parameters": [
+          {
+            "name": "enabled",
+            "type": "boolean",
+            "description": "true to enable, false to disable"
+          }
+        ]
+      },
+      {
         "name": "deleteLocal",
         "type": "function",
         "description": "Deletes the local records of the specified collection",


### PR DESCRIPTION
Fix #251

I am not convinced about the approach, but also can't think of anything better...

In Gecko, signature verification can be enabled/disabled at the collection object level.
From a DevTools/UI/UX point of view, I don't see any value in offering the option to enable/disable for each collection. So I decided to go for a global switch.

This has one small disavantage: user clicks disable. It's disabled for all instantiated clients. A new client is instantiated (manually or within a component firefox). It has signature enabled. UI shows enabled again. User has to click to disable again.

And also:

* [x] Fix apparence of new Option section below History
* [x] Do not use `<div>` but CSS to organize UI